### PR TITLE
skip unsafe characters, at least on windows

### DIFF
--- a/src/Command/ExportByChatCommand.php
+++ b/src/Command/ExportByChatCommand.php
@@ -160,7 +160,8 @@ class ExportByChatCommand extends Command
         $destination = str_replace("<chatname>", $this->input->getArgument('chatname'), $destination);
 
         // replace unsafe chars
-        $destination = strtr($destination, DIRECTORY_SEPARATOR, '_');
+        $destination = strtr($destination, '/', '_');
+        $destination = strtr($destination, '\\', '_');
         $destination = strtr($destination, ':', '_');
         $destination = strtr($destination, '*', '_');
 

--- a/src/Command/ExportByChatCommand.php
+++ b/src/Command/ExportByChatCommand.php
@@ -162,6 +162,7 @@ class ExportByChatCommand extends Command
         // replace unsafe chars
         $destination = strtr($destination, DIRECTORY_SEPARATOR, '_');
         $destination = strtr($destination, ':', '_');
+        $destination = strtr($destination, '*', '_');
 
         return $destination;
     }

--- a/src/Command/ExportByChatCommand.php
+++ b/src/Command/ExportByChatCommand.php
@@ -141,6 +141,9 @@ class ExportByChatCommand extends Command
         $destination = $destination.'.csv';
 
         $fh = fopen($destination, "w+");
+        if (!$fh) {
+            throw new \InvalidArgumentException('Failed to open output file for write');
+        }
         foreach ($data as $row) {
             fputcsv($fh, $row, ',');
         }

--- a/src/Command/ExportByChatCommand.php
+++ b/src/Command/ExportByChatCommand.php
@@ -161,6 +161,7 @@ class ExportByChatCommand extends Command
 
         // replace unsafe chars
         $destination = strtr($destination, DIRECTORY_SEPARATOR, '_');
+        $destination = strtr($destination, ':', '_');
 
         return $destination;
     }


### PR DESCRIPTION
the error being:

```
PHP Warning:  fopen(skype-log-19:blablbla@thread.skype.csv): failed to open stream: Protocol error in phar:///vagrant/skype-logs.phar/src/Command/ExportByChatCommand.php on line 143
```
